### PR TITLE
Fixing issue #22 (Duplicate key exception when specifying "--file" argument)

### DIFF
--- a/FakeServer/Program.cs
+++ b/FakeServer/Program.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -35,7 +35,9 @@ namespace FakeServer
             }
 
             MainConfiguration.Add("currentPath", Directory.GetCurrentDirectory());
-            MainConfiguration.Add("file", file ?? "datastore.json");
+
+            if (!MainConfiguration.ContainsKey("file"))
+                MainConfiguration.Add("file", file ?? "datastore.json");
 
             var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
 


### PR DESCRIPTION
Checking for the existence of a "file" key in the MainConfiguration dictionary before adding a new one.  This avoids a duplicate key exception when the user specifies a `--file` argument through the command-line.

This fixes issue #22 