### PR TITLE
Adds console argument --version.

### DIFF
--- a/FakeServer/Program.cs
+++ b/FakeServer/Program.cs
@@ -6,7 +6,9 @@ using Microsoft.Extensions.PlatformAbstractions;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 
 namespace FakeServer
 {
@@ -14,6 +16,8 @@ namespace FakeServer
     {
         public static int Main(string[] args)
         {
+            CheckForVersionFlag(args);
+
             var inMemoryCollection = ParseInMemoryCollection(args);
 
             if (inMemoryCollection.ContainsKey("staticFolder"))
@@ -71,6 +75,23 @@ namespace FakeServer
                .UseConfiguration(config)
                .UseStartup<Startup>()
                .UseSerilog();
+
+        private static void CheckForVersionFlag(string[] args)
+        {
+            for (var i = 0; i < args.Length; i++)
+            {
+                if (args[i] == "--version")
+                {
+                    Console.WriteLine(GetAssemblyVersion());
+                    Environment.Exit(0);
+                }
+            }
+        }
+        
+        private static string GetAssemblyVersion()
+        {
+            return FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+        }
 
         private static Dictionary<string, string> ParseInMemoryCollection(string[] args)
         {

--- a/FakeServer/Program.cs
+++ b/FakeServer/Program.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace FakeServer
@@ -16,7 +17,11 @@ namespace FakeServer
     {
         public static int Main(string[] args)
         {
-            CheckForVersionFlag(args);
+            if (args.Any(arg => arg == "--version"))
+            {
+                Console.WriteLine(GetAssemblyVersion());
+                return 0;
+            }
 
             var inMemoryCollection = ParseInMemoryCollection(args);
 
@@ -75,18 +80,6 @@ namespace FakeServer
                .UseConfiguration(config)
                .UseStartup<Startup>()
                .UseSerilog();
-
-        private static void CheckForVersionFlag(string[] args)
-        {
-            for (var i = 0; i < args.Length; i++)
-            {
-                if (args[i] == "--version")
-                {
-                    Console.WriteLine(GetAssemblyVersion());
-                    Environment.Exit(0);
-                }
-            }
-        }
         
         private static string GetAssemblyVersion()
         {


### PR DESCRIPTION
Running the application with --version will show the current product
version, and then immediately terminate the program.  The flag -v was
not used because that is a shorthand for the --verbose flag which is
a flag already in dotnet run.