### PR TITLE
Fixed XML singular/pluralization

### DIFF
--- a/FakeServer.Test/FakeServerSpecs.cs
+++ b/FakeServer.Test/FakeServerSpecs.cs
@@ -108,11 +108,20 @@ namespace FakeServer.Test
             var result = await _fixture.Client.SendAsync(request);
             result.EnsureSuccessStatusCode();
 
-            var rows = await result.Content.ReadAsStringAsync();
-            Assert.False(string.IsNullOrEmpty(rows));
+            var xml = await result.Content.ReadAsStringAsync();
+            Assert.False(string.IsNullOrEmpty(xml));
+
             // Check that inner collections are serialized correctly
-            Assert.DoesNotContain("[id, 0]", rows);
-            Assert.DoesNotContain("System.Collections.Generic.List", rows);
+            Assert.DoesNotContain("[id, 0]", xml);
+            Assert.DoesNotContain("System.Collections.Generic.List", xml);
+
+            var rows = xml.Split(Environment.NewLine);
+            Assert.Equal("<family>", rows[0].Trim());
+            Assert.Equal("<parents>", rows[3].Trim());
+            Assert.Equal("<parent>", rows[4].Trim());
+            Assert.Equal("<children>", rows[33].Trim());
+            Assert.Equal("<child>", rows[34].Trim());
+            Assert.Equal("<work>", rows[12].Trim());
         }
 
         [Fact]

--- a/FakeServer/Common/Formatters/XmlOutputFormatter.cs
+++ b/FakeServer/Common/Formatters/XmlOutputFormatter.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Pluralize.NET.Core;
 
 namespace FakeServer.Common.Formatters
 {
@@ -24,20 +25,19 @@ namespace FakeServer.Common.Formatters
         protected override bool CanWriteType(Type type) =>
                 typeof(ExpandoObject).IsAssignableFrom(type) || typeof(IEnumerable<object>).IsAssignableFrom(type) ? base.CanWriteType(type) : false;
 
+        private static Pluralizer pluralizer = new Pluralizer();
+
         public async override Task WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding selectedEncoding)
         {
-            // TODO: Fix collection element naming. Current implementation:
-            // <families>
-            //   <families_0>
-
             XElement HandleExpandoField(XElement acc, KeyValuePair<string, object> fields)
             {
                 XElement element = null;
 
+
                 if (fields.Value is IEnumerable<object> innerList)
                 {
-                    var children = innerList.Select((i, idx) => ((ExpandoObject)i).Aggregate(new XElement($"{fields.Key}_{idx}"), HandleExpandoField));
-                    element = new XElement(fields.Key, children);
+                    var children = innerList.Select((i, idx) => ((ExpandoObject)i).Aggregate(new XElement($"{pluralizer.Singularize(fields.Key)}_{idx}"), HandleExpandoField));
+                    element = new XElement(pluralizer.Pluralize(fields.Key), children);
                 }
                 else
                 {
@@ -52,8 +52,8 @@ namespace FakeServer.Common.Formatters
 
             XElement MultipleItemsToXml(string name, IEnumerable<object> itemCollection)
             {
-                var children = itemCollection.Select((i, idx) => ((ExpandoObject)i).Aggregate(new XElement($"{name}_{idx}"), HandleExpandoField));
-                var root = new XElement(name, children);
+                var children = itemCollection.Select((i, idx) => ((ExpandoObject)i).Aggregate(new XElement($"{pluralizer.Singularize(name)}_{idx}"), HandleExpandoField));
+                var root = new XElement(pluralizer.Pluralize(name), children);
                 return root;
             }
 
@@ -62,7 +62,7 @@ namespace FakeServer.Common.Formatters
                 return obj.Aggregate(new XElement(name), HandleExpandoField);
             }
 
-            var itemName = ObjectHelper.GetCollectionFromPath(context.HttpContext.Request.Path.Value);
+            var itemName = pluralizer.Singularize(ObjectHelper.GetCollectionFromPath(context.HttpContext.Request.Path.Value));
 
             var xml = context.Object is IEnumerable<object> col ? MultipleItemsToXml(itemName, col) : SingleItemToXml(itemName, context.Object as ExpandoObject);
 

--- a/FakeServer/Common/Formatters/XmlOutputFormatter.cs
+++ b/FakeServer/Common/Formatters/XmlOutputFormatter.cs
@@ -25,7 +25,7 @@ namespace FakeServer.Common.Formatters
         protected override bool CanWriteType(Type type) =>
                 typeof(ExpandoObject).IsAssignableFrom(type) || typeof(IEnumerable<object>).IsAssignableFrom(type) ? base.CanWriteType(type) : false;
 
-        private static Pluralizer pluralizer = new Pluralizer();
+        private static Pluralizer _pluralizer = new Pluralizer();
 
         public async override Task WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding selectedEncoding)
         {
@@ -36,8 +36,8 @@ namespace FakeServer.Common.Formatters
 
                 if (fields.Value is IEnumerable<object> innerList)
                 {
-                    var children = innerList.Select((i, idx) => ((ExpandoObject)i).Aggregate(new XElement($"{pluralizer.Singularize(fields.Key)}_{idx}"), HandleExpandoField));
-                    element = new XElement(pluralizer.Pluralize(fields.Key), children);
+                    var children = innerList.Select((i) => ((ExpandoObject)i).Aggregate(new XElement($"{_pluralizer.Singularize(fields.Key)}"), HandleExpandoField));
+                    element = new XElement(_pluralizer.Pluralize(fields.Key), children);
                 }
                 else
                 {
@@ -52,8 +52,8 @@ namespace FakeServer.Common.Formatters
 
             XElement MultipleItemsToXml(string name, IEnumerable<object> itemCollection)
             {
-                var children = itemCollection.Select((i, idx) => ((ExpandoObject)i).Aggregate(new XElement($"{pluralizer.Singularize(name)}_{idx}"), HandleExpandoField));
-                var root = new XElement(pluralizer.Pluralize(name), children);
+                var children = itemCollection.Select((i) => ((ExpandoObject)i).Aggregate(new XElement($"{_pluralizer.Singularize(name)}"), HandleExpandoField));
+                var root = new XElement(_pluralizer.Pluralize(name), children);
                 return root;
             }
 
@@ -62,7 +62,7 @@ namespace FakeServer.Common.Formatters
                 return obj.Aggregate(new XElement(name), HandleExpandoField);
             }
 
-            var itemName = pluralizer.Singularize(ObjectHelper.GetCollectionFromPath(context.HttpContext.Request.Path.Value));
+            var itemName = _pluralizer.Singularize(ObjectHelper.GetCollectionFromPath(context.HttpContext.Request.Path.Value));
 
             var xml = context.Object is IEnumerable<object> col ? MultipleItemsToXml(itemName, col) : SingleItemToXml(itemName, context.Object as ExpandoObject);
 

--- a/FakeServer/FakeServer.csproj
+++ b/FakeServer/FakeServer.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
+    <PackageReference Include="Pluralize.NET.Core" Version="1.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />


### PR DESCRIPTION
#62 XML elements should reflect their proper pluralization.
Used suggested Pluralize framework to fix XML element pluralization

- Elements will be pluralized if they have child elements
- Child elements will be singularized
- Elements with no children will be singularized