### PR TITLE
Extend lookup for ids to various json formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * CHANGED: PATCH methods to require Content-Type: application/json+merge-patch or merge-patch+json
 * ADDED: Content negotiation with Accept-header and support for CSV and XML
 * ADDED: Client Credentials support to token authentication
+* FIXED: Identifiers can be stored in various JSON formats
 
 ### [0.10.0] - 2019-06-16
 * ADDED: Token endpoint to support username/password in JSON content

--- a/FakeServer.Test/FakeServerSpecs.cs
+++ b/FakeServer.Test/FakeServerSpecs.cs
@@ -342,7 +342,7 @@ namespace FakeServer.Test
         public async Task GetItem_WithId_Found()
         {
             var result = await _fixture.Client.GetAsync($"api/users/1");
-            Assert.Equal(System.Net.HttpStatusCode.OK, result.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
             var item = JsonConvert.DeserializeObject<JObject>(await result.Content.ReadAsStringAsync());
             Assert.Equal("James", item["name"].Value<string>());
@@ -352,7 +352,35 @@ namespace FakeServer.Test
         public async Task GetItem_WithId_NotFound()
         {
             var result = await _fixture.Client.GetAsync($"api/users/100000");
-            Assert.Equal(System.Net.HttpStatusCode.NotFound, result.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetItem_WithId_StoredInJsonAs_Integer()
+        {
+            var result = await _fixture.Client.GetAsync($"api/movies/300");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetItem_WithId_StoredInJsonAs_IntegerInString()
+        {
+            var result = await _fixture.Client.GetAsync($"api/movies/7");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetItem_WithId_StoredInJsonAs_BooleanInString()
+        {
+            var result = await _fixture.Client.GetAsync($"api/movies/true");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetItem_WithId_StoredInJsonAs_DateInString()
+        {
+            var result = await _fixture.Client.GetAsync($"api/movies/1984-01-01");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }
 
         [Fact]
@@ -477,6 +505,14 @@ namespace FakeServer.Test
             var result = await _fixture.Client.GetAsync($"api/families/18/parents/1/work");
             var workplace = JsonConvert.DeserializeObject<JObject>(await result.Content.ReadAsStringAsync());
             Assert.Equal("EVIDENDS", workplace["companyName"].Value<string>());
+        }
+
+        [Fact]
+        public async Task GetItem_Nested_WithId_StoredInJsonAs_IntegerInString()
+        {
+            var result = await _fixture.Client.GetAsync($"api/movies/300/sequels/3002");
+            var sequel = JsonConvert.DeserializeObject<JObject>(await result.Content.ReadAsStringAsync());
+            Assert.Equal("300: Rise of an Empire", sequel["name"].Value<string>());
         }
 
         [Fact]

--- a/FakeServer.Test/ObjectHelperTests.cs
+++ b/FakeServer.Test/ObjectHelperTests.cs
@@ -54,6 +54,20 @@ namespace FakeServer.Test
         }
 
         [Fact]
+        public void GetIdAsCorrectType_ReturnsDynamicOtherThanString()
+        {
+            Assert.IsType<int>(ObjectHelper.GetIdAsCorrectType("2"));
+            Assert.IsType<double>(ObjectHelper.GetIdAsCorrectType("2.1"));
+            Assert.IsType<string>(ObjectHelper.GetIdAsCorrectType("somevalue"));
+        }
+
+        [Fact]
+        public void GetIdAsCorrectType_ReturnsString_WhenDateInString()
+        {
+            Assert.IsType<string>(ObjectHelper.GetIdAsCorrectType("7/31/2017"));
+        }
+
+        [Fact]
         public void OperatorFunctions()
         {
             Assert.True(ObjectHelper.Funcs[""](2, 2));

--- a/FakeServer/Common/ModelBinders.cs
+++ b/FakeServer/Common/ModelBinders.cs
@@ -29,7 +29,7 @@ namespace FakeServer.Common
             var stringValue = value.ToString();
             bindingContext.ModelState.SetModelValue(bindingContext.ModelName, stringValue, stringValue);
 
-            dynamic convertedId = ObjectHelper.GetValueAsCorrectType(stringValue);
+            dynamic convertedId = ObjectHelper.GetIdAsCorrectType(stringValue);
             bindingContext.Result = ModelBindingResult.Success(convertedId);
 
             return Task.CompletedTask;

--- a/FakeServer/Common/ObjectHelper.cs
+++ b/FakeServer/Common/ObjectHelper.cs
@@ -105,6 +105,9 @@ namespace FakeServer.Common
         /// <summary>
         /// Compare the field value from a source object to the provided id.
         /// </summary>
+        /// <remarks>
+        /// If the field value is a string, it is also compared to the string representation of the provided id.
+        /// </remarks>
         /// <param name="source"></param>
         /// <param name="fieldName"></param>
         /// <param name="id"></param>
@@ -115,6 +118,9 @@ namespace FakeServer.Common
 
             if (fieldValue.Equals(id))
                 return true;
+
+            if (fieldValue.GetType() == typeof(string) && id.GetType() != typeof(string))
+                return fieldValue == id.ToString().ToLower();
 
             return false;
         }

--- a/FakeServer/Common/ObjectHelper.cs
+++ b/FakeServer/Common/ObjectHelper.cs
@@ -75,9 +75,9 @@ namespace FakeServer.Common
                 tail = tail.Contains('/') ? tail.Substring(tail.IndexOf('/') + 1) : string.Empty;
 
                 if (currentValue is IEnumerable<dynamic> valueEnumerable)
-                    returnValue = valueEnumerable.FirstOrDefault(e => GetFieldValue(e, idFieldName) == parsedInteger);
+                    returnValue = valueEnumerable.FirstOrDefault(e => CompareFieldValueWithId(e, idFieldName, parsedInteger));
                 else
-                    returnValue = GetFieldValue(((dynamic)currentValue), idFieldName) == parsedInteger ? currentValue as ExpandoObject : null;
+                    returnValue = CompareFieldValueWithId(((dynamic)currentValue), idFieldName, parsedInteger) ? currentValue as ExpandoObject : null;
             }
             else
             {
@@ -100,6 +100,23 @@ namespace FakeServer.Common
 
             var srcProp = source.GetType().GetProperties().FirstOrDefault(p => string.Equals(p.Name, fieldName, StringComparison.OrdinalIgnoreCase));
             return srcProp?.GetValue(source, null);
+        }
+
+        /// <summary>
+        /// Compare the field value from a source object to the provided id.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="fieldName"></param>
+        /// <param name="id"></param>
+        /// <returns>The field value from is equal to the provided id</returns>
+        public static bool CompareFieldValueWithId(object source, string fieldName, dynamic id)
+        {
+            dynamic fieldValue = ObjectHelper.GetFieldValue(source, fieldName);
+
+            if (fieldValue.Equals(id))
+                return true;
+
+            return false;
         }
 
         public static void SetFieldValue(object item, string fieldName, dynamic data)

--- a/FakeServer/Common/ObjectHelper.cs
+++ b/FakeServer/Common/ObjectHelper.cs
@@ -188,14 +188,14 @@ namespace FakeServer.Common
             x => DateTime.Parse(x, CultureInfo.InvariantCulture)
         };
 
-        /// <summary>
-        /// Convert input value to correct type
-        /// </summary>
-        /// <param name="value">input</param>
-        /// <returns>value as an integer, as a double or as a string</returns>
-        public static dynamic GetValueAsCorrectType(string value)
+        private static Lazy<List<Func<string, dynamic>>> _convertFuncsExceptDateTime = new Lazy<List<Func<string, dynamic>>>(
+            () => _convertFuncs.Take(3).ToList());
+        
+        private static List<Func<string, dynamic>> _convertIdFuncs => _convertFuncsExceptDateTime.Value;
+
+        private static dynamic GetValueAsCorrectType(string value, List<Func<string, dynamic>> convertFuncs)
         {
-            foreach (var func in _convertFuncs)
+            foreach (var func in convertFuncs)
             {
                 try
                 {
@@ -208,6 +208,20 @@ namespace FakeServer.Common
 
             return value;
         }
+
+        /// <summary>
+        /// Convert a value to correct type
+        /// </summary>
+        /// <param name="value">the input value</param>
+        /// <returns>value as a boolean, an integer, a double, a DateTime or as a string</returns>
+        public static dynamic GetValueAsCorrectType(string value) => GetValueAsCorrectType(value, _convertFuncs);
+
+        /// <summary>
+        /// Convert the value of an identifier from JSON to correct type.
+        /// </summary>
+        /// <param name="id">the input id</param>
+        /// <returns>value as a boolean, an integer, a double or as a string</returns>
+        public static dynamic GetIdAsCorrectType(string id) => GetValueAsCorrectType(id, _convertIdFuncs);
 
         /// <summary>
         /// Try to cast value from JSON file to correct type.

--- a/FakeServer/Controllers/DynamicController.cs
+++ b/FakeServer/Controllers/DynamicController.cs
@@ -175,7 +175,7 @@ namespace FakeServer.Controllers
             if (_ds.IsItem(collectionId))
                 return BadRequest();
 
-            var result = _ds.GetCollection(collectionId).Find(e => ObjectHelper.GetFieldValue(e, _dsSettings.IdField) == id).FirstOrDefault();
+            var result = _ds.GetCollection(collectionId).Find(e => ObjectHelper.CompareFieldValueWithId(e, _dsSettings.IdField, id)).FirstOrDefault();
 
             if (result == null)
                 return NotFound();
@@ -203,7 +203,7 @@ namespace FakeServer.Controllers
             if (_ds.IsItem(collectionId))
                 return BadRequest();
 
-            var item = _ds.GetCollection(collectionId).AsQueryable().FirstOrDefault(e => ObjectHelper.GetFieldValue(e, _dsSettings.IdField) == id);
+            var item = _ds.GetCollection(collectionId).AsQueryable().FirstOrDefault(e => ObjectHelper.CompareFieldValueWithId(e, _dsSettings.IdField, id));
 
             if (item == null)
                 return BadRequest();

--- a/FakeServer/datastore.json
+++ b/FakeServer/datastore.json
@@ -47,10 +47,39 @@
   ],
   "movies": [
     {
-      "name": "Die Hard"
+      "id": "die-hard",
+      "name": "Die Hard",
+      "sequels": []
     },
     {
-      "name": "Predator"
+      "id": "predator",
+      "name": "Predator",
+      "sequels": []
+    },
+    {
+      "id": "7",
+      "name": "Se7en",
+      "sequels": []
+    },
+    {
+      "id": 300,
+      "name": "300",
+      "sequels": [
+        {
+          "id": "3002",
+          "name": "300: Rise of an Empire"
+        }
+      ]
+    },
+    {
+      "id": "true",
+      "name":  "True Story",
+      "sequels": []
+    },
+    {
+      "id": "1984-01-01",
+      "name":  "1984",
+      "sequels": []
     }
   ],
   "families": [


### PR DESCRIPTION
Support the lookup of objects with an identifier stored as various formats in the JSON database, eg

- GET /api/collection/310 should retrieve an object with the numeric identifier 310, but also an object with the string identifier "310"

- the behavior described above is also expected for JSON types double and boolean

- the behavior described above works for queries with nested parameters, such as GET /api/collection/310/subitem/311