### PR TITLE
feat: add health check endpoint

### DIFF
--- a/FakeServer.Test/FakeServer.Test.csproj
+++ b/FakeServer.Test/FakeServer.Test.csproj
@@ -19,6 +19,7 @@
     <ItemGroup>
         <PackageReference Include="JsonFlatFileDataStore" Version="2.4.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="WebSocket4Net" Version="0.15.2" />
         <PackageReference Include="xunit" Version="2.5.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">

--- a/FakeServer.Test/HealthCheckControllerTests.cs
+++ b/FakeServer.Test/HealthCheckControllerTests.cs
@@ -1,0 +1,67 @@
+﻿using NSubstitute;
+using Xunit;
+using JsonFlatFileDataStore;
+using FakeServer.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+
+namespace FakeServer.Test;
+
+public class HealthCheckControllerTests
+{
+    private readonly IDataStore _mockDataStore;
+    private readonly HealthCheckController _controller;
+
+    public HealthCheckControllerTests()
+    {
+        _mockDataStore = Substitute.For<IDataStore>();
+        _controller = new HealthCheckController(_mockDataStore);
+    }
+
+    [Fact]
+    public void Get_ReturnsHealthyStatus_WhenDataStoreIsAccessible()
+    {
+        // Arrange
+        // For the healthy case, we just need to ensure Reload() doesn't throw an exception
+        // This is the default behavior for NSubstitute, so no explicit configuration is needed
+
+        // Act
+        var result = _controller.Get() as OkObjectResult;
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(StatusCodes.Status200OK, result.StatusCode);
+
+        var responseDict = result.Value as Dictionary<string, string>;
+        Assert.NotNull(responseDict);
+        Assert.True(responseDict.ContainsKey("status"), "Response should contain 'status' key");
+        Assert.Equal("Healthy", responseDict["status"]);
+        Assert.True(responseDict.ContainsKey("uptime"), "Response should contain 'uptime' key");
+        Assert.NotNull(responseDict["uptime"]);
+        Assert.True(responseDict.ContainsKey("version"), "Response should contain 'version' key");
+        Assert.NotNull(responseDict["version"]);
+    }
+
+    [Fact]
+    public void Get_ReturnsUnhealthyStatus_WhenDataStoreIsInaccessible()
+    {
+        // Arrange
+        // Configure _mockDataStore.Reload() to throw an exception to simulate failure
+        _mockDataStore.When(ds => ds.Reload()).Do(x => { throw new Exception("Data store error"); });
+
+        // Act
+        var result = _controller.Get() as ObjectResult;
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+
+        // The controller now returns a Dictionary<string, object>
+        var responseDict = result.Value as Dictionary<string, string>;
+        Assert.NotNull(responseDict);
+        Assert.True(responseDict.ContainsKey("status"), "Response should contain 'status' key");
+        Assert.Equal("Unhealthy", responseDict["status"]);
+        Assert.True(responseDict.ContainsKey("version"), "Response should contain 'version' key");
+        Assert.NotNull(responseDict["version"]);
+    }
+}

--- a/FakeServer/Controllers/HealthCheckController.cs
+++ b/FakeServer/Controllers/HealthCheckController.cs
@@ -1,0 +1,93 @@
+﻿using System.Reflection;
+using System.Collections.Generic;
+using JsonFlatFileDataStore;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FakeServer.Controllers;
+
+/// <summary>
+/// Controller that provides health check functionality for the Fake JSON Server.
+/// Monitors critical dependencies and reports service status, uptime, and version information.
+/// </summary>
+[ApiController]
+[Route("health")]
+public class HealthCheckController : ControllerBase
+{
+    private static readonly DateTime _startTime = DateTime.UtcNow;
+    private readonly string _version;
+    private readonly IDataStore _ds;
+
+    public HealthCheckController(IDataStore ds)
+    {
+        // Get the version from the executing assembly or set a default
+        _version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.0.0";
+        _ds = ds;
+    }
+
+    /// <summary>
+    /// Retrieves health status of the application
+    /// </summary>
+    /// <remarks>
+    /// Provides current health information about the system, including:
+    /// - Status: "Healthy" when all services are operational, "Unhealthy" otherwise
+    /// - Uptime: Duration since application startup in days, hours, and minutes
+    /// - Version: Application version number
+    ///
+    /// Example: GET /health
+    /// </remarks>
+    /// <returns>Health status object</returns>
+    /// <response code="200">Application is healthy</response>
+    /// <response code="503">Application is unhealthy, data store is inaccessible</response>
+    [HttpGet]
+    public IActionResult Get()
+    {
+        // Calculate uptime once
+        TimeSpan uptime = DateTime.UtcNow - _startTime;
+        string formattedUptime = FormatUptime(uptime);
+
+        try
+        {
+            // Check if data store is accessible
+            _ds.Reload();
+
+            var result = new Dictionary<string, string>
+                {
+                    { "status", "Healthy" },
+                    { "uptime", formattedUptime },
+                    { "version", _version }
+                };
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            var result = new Dictionary<string, string>
+                {
+                    { "status", "Unhealthy" },
+                    { "version", _version }
+                };
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, result);
+        }
+    }
+
+    private string FormatUptime(TimeSpan timeSpan)
+    {
+        if (timeSpan.TotalDays >= 1)
+        {
+            int days = (int)timeSpan.TotalDays;
+            int hours = timeSpan.Hours;
+            int minutes = timeSpan.Minutes;
+            return $"{days} day{(days == 1 ? "" : "s")}, {hours} hour{(hours == 1 ? "" : "s")}, {minutes} minute{(minutes == 1 ? "" : "s")}";
+        }
+        else if (timeSpan.TotalHours >= 1)
+        {
+            int hours = (int)timeSpan.TotalHours;
+            int minutes = timeSpan.Minutes;
+            return $"{hours} hour{(hours == 1 ? "" : "s")}, {minutes} minute{(minutes == 1 ? "" : "s")}";
+        }
+        else
+        {
+            int minutes = (int)timeSpan.TotalMinutes;
+            return $"{minutes} minute{(minutes == 1 ? "" : "s")}";
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Fake JSON Server is a Fake REST API that can be used as a Back End for prototypi
     + [Data Store Id-field name](#data-store-id-field-name)
     + [Eager data reload](#eager-data-reload)
     + [Reload](#reload)
+    + [Health Check](#health-check)
   * [Endpoints](#endpoints)
     + [JSON data used in examples](#json-data-used-in-examples)
     + [List collections (GET)](#list-collections-get)
@@ -591,6 +592,7 @@ GET      /
 POST     /token
 POST     /logout
 POST     /admin/reload
+GET      /health
 
 GET      /api
 HEAD     /api
@@ -716,6 +718,50 @@ Reload endpoint can be used to reload JSON data from the file to Data Store. End
 ```sh
 $ curl -X POST http://localhost:57602/admin/reload --data ""
 ```
+
+### Health Check
+
+The health check endpoint provides status information about the Fake JSON Server. It monitors critical dependencies (like the data store) and reports service status, uptime, and version information.
+
+```
+> GET /health
+
+200 OK                        : Application is healthy
+503 Service Unavailable       : Application is unhealthy (data store is inaccessible)
+```
+
+The response contains:
+- `status`: "Healthy" when all services are operational, "Unhealthy" otherwise
+- `uptime`: Duration since application startup in days, hours, and minutes (only when healthy)
+- `version`: Application version number
+
+Example of a healthy response:
+
+```sh
+$ curl http://localhost:57602/health
+```
+
+```json
+{
+  "status": "Healthy",
+  "uptime": "2 days, 5 hours, 30 minutes",
+  "version": "1.0.0"
+}
+```
+
+Example of an unhealthy response:
+
+```json
+{
+  "status": "Unhealthy",
+  "version": "1.0.0"
+}
+```
+
+This endpoint is useful for:
+- Monitoring service health in production environments
+- Integration with container orchestration systems for health probes
+- Checking if the data store is accessible
 
 ### Endpoints
 


### PR DESCRIPTION
The health check endpoint provides status information about the Fake JSON Server. It monitors critical dependencies (like the data store) and reports service status, uptime, and version information.