### PR TITLE
ci: replace Travis CI with GitHub Actions #129

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+  schedule:
+    - cron: '0 0 * * 0'  # Runs at 00:00 UTC every Sunday
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
             **/*.csproj
             **/*.props
             **/*.targets
-            global.json
 
       - name: Restore
         run: dotnet restore FakeServer.sln

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ master ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ master ]
   schedule:
     - cron: '0 0 * * 0'  # Runs at 00:00 UTC every Sunday
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/*.props
+            **/*.targets
+            global.json
+
+      - name: Restore
+        run: dotnet restore FakeServer.sln
+
+      - name: Build
+        run: dotnet build FakeServer.sln --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test FakeServer.sln --no-build --configuration Release --verbosity normal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: csharp
-os: linux
-dist: focal
-mono: none
-dotnet: 8.0.14 
-solution: FakeServer.sln
-script:
-  - dotnet restore
-  - dotnet build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fake JSON Server
 
 | Build server | Platform       | Build status |
 |--------------|----------------|-------------|
-| Travis       | Linux / macOS  |[![Build Status](https://app.travis-ci.com/ttu/dotnet-fake-json-server.svg?branch=master)](https://app.travis-ci.com/ttu/dotnet-fake-json-server)| 
+| GitHub Actions | Linux / macOS | [![CI](https://github.com/ttu/dotnet-fake-json-server/actions/workflows/ci.yml/badge.svg)](https://github.com/ttu/dotnet-fake-json-server/actions/workflows/ci.yml) |
 | CircleCI     | Windows        |[![CircleCI](https://dl.circleci.com/status-badge/img/gh/ttu/dotnet-fake-json-server/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/ttu/dotnet-fake-json-server/tree/master)|
 
 Fake JSON Server is a Fake REST API that can be used as a Back End for prototyping or as a template for a CRUD Back End. Fake JSON Server also has an experimental GraphQL query and mutation support.


### PR DESCRIPTION
## Description
As requested in #129, this PR migrates the CI pipeline from Travis CI to GitHub Actions. This provides a more reliable and modern build environment for the project.

## Changes
- **Added** `.github/workflows/ci.yml`: A new workflow that builds and tests the solution on every push and pull request.
- **Removed** `.travis.yml`: Legacy Travis configuration.

## Technical Details
- **Runner:** `ubuntu-latest`
- **SDK:** .NET 8.0.x (aligns with current project target)
- **Steps:** Restore -> Build -> Test (Release configuration)

Fixes #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated continuous integration from Travis CI to GitHub Actions; CI now runs on pushes, pull requests, and a weekly schedule, with build/test targeting .NET 8, concurrency control, and caching to speed runs.
* **Chores**
  * Removed legacy Travis CI configuration.
* **Documentation**
  * Updated README build-status badge to reference the new CI workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->